### PR TITLE
Fixed an import error and pulled in code from other forks.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ such, its tests are runable by most test runners. If you have nose installed,
 you can do the following::
 
   $ git clone https://github.com/oubiwann/metaphone.git
-  $ cd double-metaphone
+  $ cd metaphone
   $ nosetests -v .
 
 If you have Twisted installed, you can do::

--- a/README.rst
+++ b/README.rst
@@ -99,9 +99,11 @@ a taste::
   $ python
   >>> from metaphone import doublemetaphone
   >>> doublemetaphone("architect")
-  ("ARKTKT", "")
+  (u"ARKTKT", u"")
   >>> doublemetaphone("bajador")
-  ("PJTR", "PHTR")
+  (u"PJTR", u"PHTR")
+  >>> doublemetaphone("Τι είναι το Unicode;")
+  (u'NKT', u'')
 
 In the Wild
 ===========

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Running the Unit Tests
 such, its tests are runable by most test runners. If you have nose installed,
 you can do the following::
 
-  $ git checkout https://github.com/oubiwann/metaphone.git
+  $ git clone https://github.com/oubiwann/metaphone.git
   $ cd double-metaphone
   $ nosetests -v .
 

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Usage
 Running the Unit Tests
 ----------------------
 ``metaphone`` uses the ``unittest`` package from the standard library, and as
-such, its tests are runable by most test runners. If you have nose installed,
+such, its tests are runnable by most test runners. If you have `nose`_ installed,
 you can do the following::
 
   $ git clone https://github.com/oubiwann/metaphone.git
@@ -130,3 +130,4 @@ The following developers/projects make use of this library:
 .. _Duncan McGreggor: https://github.com/oubiwann/
 .. _quite well: http://theatricalia.com/search?q=chuck+iwugee
 .. _φarsk project: https://github.com/oubiwann/tharsk
+.. _nose: https://nose.readthedocs.org/

--- a/metaphone/__init__.py
+++ b/metaphone/__init__.py
@@ -1,1 +1,1 @@
-from metaphone import doublemetaphone, dm
+from .metaphone import doublemetaphone, dm

--- a/metaphone/meta.py
+++ b/metaphone/meta.py
@@ -1,6 +1,6 @@
 display_name = "Metaphone"
 library_name = "metaphone"
-version = "0.4"
+version = "0.5"
 author = "Andrew Collins"
 author_email = "AtomBoy@SWCP.com"
 license = "BSD"

--- a/metaphone/metaphone.py
+++ b/metaphone/metaphone.py
@@ -41,7 +41,9 @@ created by Andrew Collins on January 12, 2007, using the C source
   Updated 2012-07    - Fixed long lines, added more docs, changed names,
                        reformulated as objects, fixed a bug in 'G'
                        (0.4; Duncan McGreggor)
+  Updated 2013-06    - Enforced unicode literals (0.5; Ian Beaver)
 """
+from __future__ import unicode_literals
 from word import Word
 
 

--- a/metaphone/tests/test_metaphone.py
+++ b/metaphone/tests/test_metaphone.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import unittest
 
 from metaphone.metaphone import doublemetaphone

--- a/metaphone/tests/test_word.py
+++ b/metaphone/tests/test_word.py
@@ -14,16 +14,40 @@ class WordTestCase(unittest.TestCase):
         self.assertEqual(word.normalized, "stupendous")
         self.assertEqual(word.upper, "STUPENDOUS")
         self.assertEqual(word.length, 10)
-        self.assertEqual(word.buffer, u"--STUPENDOUS------")
+        self.assertEqual(word.buffer, "--STUPENDOUS------")
 
     def test_init_unicode(self):
+        word = Word("Çç")
+        self.assertEqual(word.original, "\xc3\x87\xc3\xa7")
+        self.assertEqual(word.decoded, u"ss")
+        self.assertEqual(word.normalized, u"ss")
+        self.assertEqual(word.upper, u"SS")
+        self.assertEqual(word.length, 2)
+        self.assertEqual(word.buffer, u"--SS------")
+
+        word = Word(u"Çç")
+        self.assertEqual(word.original, u"\xc7\xe7")
+        self.assertEqual(word.decoded, u"ss")
+        self.assertEqual(word.normalized, u"ss")
+        self.assertEqual(word.upper, u"SS")
+        self.assertEqual(word.length, 2)
+        self.assertEqual(word.buffer, u"--SS------")
+
         word = Word("naïve")
         self.assertEqual(word.original, "na\xc3\xafve")
         self.assertEqual(word.decoded, u"na\xefve")
         self.assertEqual(word.normalized, "naive")
         self.assertEqual(word.upper, "NAIVE")
         self.assertEqual(word.length, 5)
-        self.assertEqual(word.buffer, u"--NAIVE------")
+        self.assertEqual(word.buffer, "--NAIVE------")
+
+        word = Word(u"naïve")
+        self.assertEqual(word.original, u"na\xefve")
+        self.assertEqual(word.decoded, u"na\xefve")
+        self.assertEqual(word.normalized, "naive")
+        self.assertEqual(word.upper, "NAIVE")
+        self.assertEqual(word.length, 5)
+        self.assertEqual(word.buffer, "--NAIVE------")
 
     def test_is_slavo_germanic(self):
         word = Word("Berkowitz")

--- a/metaphone/word.py
+++ b/metaphone/word.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import unicodedata
 
 
@@ -7,9 +8,12 @@ class Word(object):
     """
     def __init__(self, input):
         self.original = input
-        self.decoded = input.decode('utf-8', 'ignore')
-        self.decoded = self.decoded.replace(u'\xc7', "s")
-        self.decoded = self.decoded.replace(u'\xe7', "s")
+        if type(input) == str:
+            self.decoded = input.decode('utf-8', 'ignore')
+        else:
+            self.decoded = input
+        self.decoded = self.decoded.replace('\xc7', "s")
+        self.decoded = self.decoded.replace('\xe7', "s")
         self.normalized = ''.join(
             (c for c in unicodedata.normalize('NFD', self.decoded)
             if unicodedata.category(c) != 'Mn'))

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,6 @@ setup(
     license=meta.license,
     packages=find_packages(),
     long_description=open("README.rst").read(),
+    tests_require = ['nose'],
+    test_suite = 'nose.collector',
     )


### PR DESCRIPTION
Metaphone currently doesn’t work because of the `from metaphone import` statement in the `__init__.py` in the `metaphone` module. I’ve fixed that, and also grabbed the other fixes I could see in other forks and merged them into a single pull request.

(Given that olliebennett’s pull request has been around since June last year and hasn’t been merged, I’m not optimistic that these changes will get merged either.)
