### PR TITLE
Use io.open in setup.py to specify UTF-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import io
 
 from metaphone import meta
 
@@ -12,7 +13,7 @@ setup(
     url=meta.url,
     license=meta.license,
     packages=find_packages(),
-    long_description=open("README.rst").read(),
+    long_description=io.open("README.rst", encoding='utf-8').read(),
     tests_require = ['nose'],
     test_suite = 'nose.collector',
     )


### PR DESCRIPTION
This PR was originally made against a fork of this repo:
- https://github.com/al45tair/metaphone/pull/1
